### PR TITLE
import attributes added to all calls to wrap_sub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,23 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
 env:
   global:
     - GH_NAME=tobyink
     - GH_EMAIL=tobyink+autobot@cpan.org
     - secure: "qItYo2LGgq5cKJhaxAo6WqjY2uu/9lIKvKa4JXhCC+hYWMw3RLZH1gu12eRokObHZ4iD+7f2ZObpxzz8uQOvePiFWvXKbMRlCERvaxYwqdPDRvnhkJapJ9yZpsVc2OBs8w+LuHo/9dJi4LPB7YnLJl+30wTEYC44tjIKbHvgq/w="
 install:
-  - cpanm "Eval::TypeTiny" "Sub::Identify" "Sub::Name" "Types::Standard" "Types::TypeTiny"
+  - cpanm "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny"
   - cpanm "Test::Fatal" "Test::More"
   - cpanm "http://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Benchmark-Report-GitHub-0.001.tar.gz"
 script:
   - HARNESS_IS_VERBOSE=1 prove -Iinc -Ilib t
 matrix:
   include:
-    - perl: "5.20"
+    - perl: "5.26"
       env: BENCHMARKING=1
       after_success:
         - perl -Ilib t/benchmarks.pl

--- a/lib/Return/Type.pm
+++ b/lib/Return/Type.pm
@@ -13,6 +13,15 @@ use Sub::Util qw( subname set_subname );
 use Types::Standard qw( Any ArrayRef HashRef Int );
 use Types::TypeTiny qw( to_TypeTiny );
 
+my %package2attributes;
+sub import {
+	my $class = shift;
+	return unless @_;
+	my $caller = caller;
+	return unless $caller;
+	$package2attributes{$caller} = { @_ };
+}
+
 sub _inline_type_check
 {
 	my $class = shift;
@@ -111,6 +120,7 @@ sub UNIVERSAL::ReturnType :ATTR(CODE)
 	
 	no warnings qw(redefine);
 	my %args = (@$data % 2) ? (scalar => @$data) : @$data;
+	(%args) = (%args, %{ $package2attributes{$package} || {} });
 	*$symbol = __PACKAGE__->wrap_sub($referent, %args);
 }
 
@@ -187,6 +197,16 @@ C<< coerce => 1 >>:
 
 The options C<coerce_scalar> and C<coerce_list> are also available if
 you wish to enable coercion only in particular contexts.
+
+To turn these on for all C<:ReturnType> in the current package, use this:
+
+   use Return::Type coerce => 1;
+   # ...
+   sub first_item :ReturnType(scalar => Rounded) {
+      return $_[0];
+   }
+
+This will function the same as the above declaration.
 
 =head2 Power-user Inferface
 


### PR DESCRIPTION
Working on making `Scope::Upper` work, which seems to cause `panic: die`, which seems bad. This seems like a generally-useful change by itself.