### PR TITLE
Remove "eval" frame when used with Function::Parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - secure: "qItYo2LGgq5cKJhaxAo6WqjY2uu/9lIKvKa4JXhCC+hYWMw3RLZH1gu12eRokObHZ4iD+7f2ZObpxzz8uQOvePiFWvXKbMRlCERvaxYwqdPDRvnhkJapJ9yZpsVc2OBs8w+LuHo/9dJi4LPB7YnLJl+30wTEYC44tjIKbHvgq/w="
 install:
   # force and the || true are so will continue build even on Perl <5.14
-  - cpanm --force "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny" "Function::Parameters" || true
+  - cpanm --force "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny" "Function::Parameters" "Scope::Upper" || true
   - cpanm "Test::Fatal" "Test::More"
   - cpanm "http://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Benchmark-Report-GitHub-0.001.tar.gz"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ env:
     - GH_EMAIL=tobyink+autobot@cpan.org
     - secure: "qItYo2LGgq5cKJhaxAo6WqjY2uu/9lIKvKa4JXhCC+hYWMw3RLZH1gu12eRokObHZ4iD+7f2ZObpxzz8uQOvePiFWvXKbMRlCERvaxYwqdPDRvnhkJapJ9yZpsVc2OBs8w+LuHo/9dJi4LPB7YnLJl+30wTEYC44tjIKbHvgq/w="
 install:
-  - cpanm "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny"
+  # force and the || true are so will continue build even on Perl <5.14
+  - cpanm --force "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny" "Function::Parameters" || true
   - cpanm "Test::Fatal" "Test::More"
   - cpanm "http://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Benchmark-Report-GitHub-0.001.tar.gz"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,23 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
 env:
   global:
     - GH_NAME=tobyink
     - GH_EMAIL=tobyink+autobot@cpan.org
     - secure: "qItYo2LGgq5cKJhaxAo6WqjY2uu/9lIKvKa4JXhCC+hYWMw3RLZH1gu12eRokObHZ4iD+7f2ZObpxzz8uQOvePiFWvXKbMRlCERvaxYwqdPDRvnhkJapJ9yZpsVc2OBs8w+LuHo/9dJi4LPB7YnLJl+30wTEYC44tjIKbHvgq/w="
 install:
-  - cpanm "Eval::TypeTiny" "Sub::Identify" "Sub::Name" "Types::Standard" "Types::TypeTiny"
+  - cpanm "Eval::TypeTiny" "Sub::Util" "Types::Standard" "Types::TypeTiny"
   - cpanm "Test::Fatal" "Test::More"
   - cpanm "http://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Benchmark-Report-GitHub-0.001.tar.gz"
 script:
   - HARNESS_IS_VERBOSE=1 prove -Iinc -Ilib t
 matrix:
   include:
-    - perl: "5.20"
+    - perl: "5.26"
       env: BENCHMARKING=1
       after_success:
         - perl -Ilib t/benchmarks.pl

--- a/lib/Return/Type.pm
+++ b/lib/Return/Type.pm
@@ -13,6 +13,15 @@ use Sub::Util qw( subname set_subname );
 use Types::Standard qw( Any ArrayRef HashRef Int );
 use Types::TypeTiny qw( to_TypeTiny );
 
+my %package2attributes;
+sub import {
+	my $class = shift;
+	return unless @_;
+	my $caller = caller;
+	return unless $caller;
+	$package2attributes{$caller} = { @_ };
+}
+
 sub _inline_type_check
 {
 	my $class = shift;
@@ -111,6 +120,7 @@ sub UNIVERSAL::ReturnType :ATTR(CODE)
 	
 	no warnings qw(redefine);
 	my %args = (@$data % 2) ? (scalar => @$data) : @$data;
+	(%args) = (%args, %{ $package2attributes{$package} || {} });
 	*$symbol = __PACKAGE__->wrap_sub($referent, %args);
 }
 
@@ -187,6 +197,16 @@ C<< coerce => 1 >>:
 
 The options C<coerce_scalar> and C<coerce_list> are also available if
 you wish to enable coercion only in particular contexts.
+
+To turn these on for all C<:ReturnType> in the current package, use this:
+
+   use Return::Type coerce => 1;
+   # ...
+   sub first_item :ReturnType(scalar => Rounded) {
+      return $_[0];
+   }
+
+This will function the same as the above declaration.
 
 =head2 Power-user Inferface
 

--- a/lib/Return/Type.pm
+++ b/lib/Return/Type.pm
@@ -72,7 +72,7 @@ sub wrap_sub
 	if ($_{scope_upper})
 	{
 		require Scope::Upper;
-		$call = '&Scope::Upper::uplevel($sub => (@_) => &Scope::Upper::SUB(&Scope::Upper::SUB))';
+		$call = '&Scope::Upper::uplevel($sub => (@_) => &Scope::Upper::SUB())';
 	}
 	
 	exists($_{$_}) || ($_{$_} = $_{coerce}) for qw( coerce_list coerce_scalar );

--- a/t/04withfp.t
+++ b/t/04withfp.t
@@ -1,0 +1,48 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test that Return::Type does add a stack frame saying C<(eval> when
+used with a L<Function::Parameters> method.
+
+=head1 AUTHOR
+
+Ed J.
+
+=head1 COPYRIGHT AND LICENCE
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+BEGIN {
+  plan skip_all => 'no Function::Parameters' unless
+    eval { require Function::Parameters; Function::Parameters->import; 1 };
+}
+
+use Test::Fatal;
+
+my $EVAL_RE = qr/\(eval/;
+
+subtest "no scope_upper means showing (eval...)" => sub
+{
+	{
+	package WithFP;
+	use Function::Parameters;
+	use Return::Type;
+	use Types::Standard -all;
+	method s(Str $s) { }
+	method s_rt(Str $s) :ReturnType(Any) { }
+	}
+
+	unlike exception { WithFP->s(undef); }, $EVAL_RE, 'no RT means no eval';
+	like exception { WithFP->s_rt(undef); }, $EVAL_RE, 'with RT means eval';
+};
+
+done_testing;

--- a/t/04withfp.t
+++ b/t/04withfp.t
@@ -5,7 +5,8 @@
 =head1 PURPOSE
 
 Test that Return::Type does add a stack frame saying C<(eval> when
-used with a L<Function::Parameters> method.
+used with a L<Function::Parameters> method, but not when used with
+C<< scope_upper => 1 >>.
 
 =head1 AUTHOR
 
@@ -24,6 +25,8 @@ use Test::More;
 BEGIN {
   plan skip_all => 'no Function::Parameters' unless
     eval { require Function::Parameters; Function::Parameters->import; 1 };
+  plan skip_all => 'no Scope::Upper' unless
+    eval { require Scope::Upper; Scope::Upper->import; 1 };
 }
 
 use Test::Fatal;
@@ -43,6 +46,22 @@ subtest "no scope_upper means showing (eval...)" => sub
 
 	unlike exception { WithFP->s(undef); }, $EVAL_RE, 'no RT means no eval';
 	like exception { WithFP->s_rt(undef); }, $EVAL_RE, 'with RT means eval';
+};
+
+subtest "with scope_upper means not showing (eval...)" => sub
+{
+	{
+	package WithFPandSU;
+	use Function::Parameters;
+	use Return::Type scope_upper => 1;
+	use Types::Standard -all;
+	method s(Str $s) { }
+	method s_rt(Str $s) :ReturnType(Any) { }
+	}
+
+	unlike exception { WithFPandSU->s(undef); }, $EVAL_RE, 'no RT and yes SU means no eval';
+	# if use 'exception' for this causes on 5.20 and 5.22: panic: die
+	eval { WithFPandSU->s_rt(undef); }; unlike $@, $EVAL_RE, 'with RT and yes SU means no eval';
 };
 
 done_testing;


### PR DESCRIPTION
Note this also includes the commits from #1.

This does not work, for reasons that are mysterious to me. It gives this error:

```
panic: die In method s_rt: parameter 1 ($s): Undef did not pass type constraint "Str" at t/04withfp.t line 63.
# Test ended with extra hubs on the stack!
    # Tests were run but no plan was declared and done_testing() was not seen.
    # Looks like your test exited with 1 just after 1.
```

Older `perldiag` (eg http://search.cpan.org/~drolsky/perl-5.17.7/pod/perldiag.pod) (not in 5.26) document `panic: die`:

```
panic: die %s

    (P) We popped the context stack to an eval context, and then discovered it wasn't an eval context.
```