### PR TITLE
add Return::Type::Lexical

### DIFF
--- a/lib/Return/Type.pm
+++ b/lib/Return/Type.pm
@@ -243,15 +243,48 @@ C<< coerce => 1 >>:
 The options C<coerce_scalar> and C<coerce_list> are also available if
 you wish to enable coercion only in particular contexts.
 
-To turn these on for all C<:ReturnType> in the current package, use this:
+=head2 Options
+
+The C<check>, C<coerce>, C<coerce_scalar>, and C<coerce_list> options
+can all be set for the whole package, lexically (see
+L<Return::Type::Lexical>) or per-subroutine using attribute options.
+
+For example, to enable coercion for an entire package:
 
    use Return::Type coerce => 1;
-   # ...
-   sub first_item :ReturnType(scalar => Rounded) {
-      return $_[0];
-   }
 
-This will function the same as the above declaration.
+Or you can use L<Devel::StrictMode> to only perform type checks in
+strict mode:
+
+   use Devel::StrictMode;
+   use Return::Type check => STRICT;
+
+If an option is set in multiple places, priority goes in this order:
+
+=over
+
+=item 1. Subroutine attribute
+
+=item 2. Lexical
+
+=item 3. Package
+
+=back
+
+In the following convoluted example, the return value of C<foo> will
+be coerced because even though coercion was disabled within the
+lexical scope in which the subroutine was defined (overriding the
+package setting), the subroutine attribute re-enabled coercion.
+
+   use Return::Type coerce => 1;
+
+   {
+      use Return::Type::Lexical coerce => 0;
+
+      sub foo :ReturnType(scalar => MyType, coerce => 1) {
+         ...
+      }
+   }
 
 =head2 Power-user Inferface
 

--- a/lib/Return/Type.pm
+++ b/lib/Return/Type.pm
@@ -13,19 +13,14 @@ use Sub::Util qw( subname set_subname );
 use Types::Standard qw( Any ArrayRef HashRef Int );
 use Types::TypeTiny qw( to_TypeTiny );
 
-my $USER_LEVEL;
 sub _find_user_package_level {
-	return $USER_LEVEL if defined $USER_LEVEL;
-
 	for (my $i = 2; $i < 10; ++$i) {
 		my ($package) = caller($i);
 		last if !$package;
 		next if $package eq 'attributes' || $package =~ /^Attribute::Handlers/;
 
-		return $USER_LEVEL = $i - 1;    # ignore current frame
+		return $i - 1;	# ignore current frame
 	}
-
-	return $USER_LEVEL = 0;
 }
 
 sub _in_effect {
@@ -72,6 +67,8 @@ sub wrap_sub
 	my $sub   = $_[0];
 	local %_  = @_[ 1 .. $#_ ];
 	
+	return $sub if !_in_effect();
+
 	$_{$_}     &&= to_TypeTiny($_{$_}) for qw( list scalar );
 	$_{scalar} ||= Any;
 	$_{list}   ||= ($_{scalar} == Any ? Any : ArrayRef[$_{scalar}]);

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -14,10 +14,16 @@ sub import {
 	my (%args) = @_;
 
 	$^H{'Return::Type::Lexical/in_effect'} = exists $args{check} && !$args{check} ? 0 : 1;
+	$^H{'Return::Type::Lexical/wrap_sub_args/coerce'} = $args{coerce} if defined $args{coerce};
+	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'} = $args{coerce_list} if defined $args{coerce_list};
+	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'} = $args{coerce_scalar} if defined $args{coerce_scalar};
 }
 
 sub unimport {
 	$^H{'Return::Type::Lexical/in_effect'} = 0;
+	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce'};
+	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'};
+	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'};
 }
 
 1;

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -1,0 +1,102 @@
+use 5.008;
+use strict;
+use warnings;
+
+package Return::Type::Lexical;
+
+our $AUTHORITY = 'cpan:TOBYINK';
+our $VERSION   = '0.005';
+
+use parent 'Return::Type';
+
+sub import {
+	my $class = shift;
+	my (%args) = @_;
+
+	$^H{'Return::Type::Lexical/in_effect'} = exists $args{check} && !$args{check} ? 0 : 1;
+}
+
+sub unimport {
+	$^H{'Return::Type::Lexical/in_effect'} = 0;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+Return::Type::Lexical - same thing as Return::Type, but lexical
+
+=head1 SYNOPSIS
+
+   use Return::Type::Lexical;
+   use Types::Standard qw(Int);
+
+   sub foo :ReturnType(Int) { return "not an int" }
+
+   {
+      no Return::Type::Lexical;
+      sub bar :ReturnType(Int) { return "not an int" }
+   }
+
+   my $foo = foo();    # throws an error
+   my $bar = bar();    # returns "not an int"
+
+   # Can also be used with Devel::StrictMode to only perform
+   # type checks in strict mode:
+
+   use Devel::StrictMode;
+   use Return::Type::Lexical check => STRICT;
+
+=head1 DESCRIPTION
+
+This module works just like L<Return::Type>, but type-checking can be
+enabled and disabled within lexical scopes.
+
+There is no runtime penalty when type-checking is disabled.
+
+=head1 METHODS
+
+The C<import> method supports the C<check> attribute to set whether or
+not types are checked.
+
+=head1 CAVEATS
+
+Disabling checks also disables coercions (if any).
+
+=head1 BUGS
+
+Please report any bugs to
+L<http://rt.cpan.org/Dist/Display.html?Queue=Return-Type>.
+
+=head1 SUPPORT
+
+B<< IRC: >> support is available through in the I<< #moops >> channel
+on L<irc.perl.org|http://www.irc.perl.org/channels.html>.
+
+=head1 SEE ALSO
+
+L<Return::Type>
+
+=head1 AUTHOR
+
+Charles McGarvey E<lt>ccm@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2020 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=head1 DISCLAIMER OF WARRANTIES
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -13,14 +13,14 @@ sub import {
 	my $class = shift;
 	my (%args) = @_;
 
-	$^H{'Return::Type::Lexical/in_effect'} = exists $args{check} && !$args{check} ? 0 : 1;
+	$^H{'Return::Type::Lexical/check'} = exists $args{check} && !$args{check} ? 0 : 1;
 	$^H{'Return::Type::Lexical/wrap_sub_args/coerce'} = $args{coerce} if defined $args{coerce};
 	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'} = $args{coerce_list} if defined $args{coerce_list};
 	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'} = $args{coerce_scalar} if defined $args{coerce_scalar};
 }
 
 sub unimport {
-	$^H{'Return::Type::Lexical/in_effect'} = 0;
+	delete $^H{'Return::Type::Lexical/check'};
 	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce'};
 	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'};
 	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'};
@@ -46,12 +46,14 @@ Return::Type::Lexical - same thing as Return::Type, but lexical
    sub foo :ReturnType(Int) { return "not an int" }
 
    {
-      no Return::Type::Lexical;
+      use Return::Type::Lexical check => 0;
       sub bar :ReturnType(Int) { return "not an int" }
+      sub baz :ReturnType(Int, check => 1) { return "not an int" }
    }
 
    my $foo = foo();    # throws an error
    my $bar = bar();    # returns "not an int"
+   my $baz = baz();    # throws an error
 
    # Can also be used with Devel::StrictMode to only perform
    # type checks in strict mode:

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -55,18 +55,21 @@ Return::Type::Lexical - same thing as Return::Type, but lexical
    my $bar = bar();    # returns "not an int"
    my $baz = baz();    # throws an error
 
-   # Can also be used with Devel::StrictMode to only perform
-   # type checks in strict mode:
-
-   use Devel::StrictMode;
-   use Return::Type::Lexical check => STRICT;
-
 =head1 DESCRIPTION
 
 This module works just like L<Return::Type>, but type-checking can be
 enabled and disabled within lexical scopes.
 
 There is no runtime penalty when type-checking is disabled.
+
+When type-checking is lexically disabled, individual subroutines can
+enable checking by setting the C<check> attribute option:
+
+   sub foo :ReturnType(scalar => Int, check => 1) {
+      ...
+   }
+
+See L<Return::Type/Options> for a more detailed explanation.
 
 =head1 METHODS
 

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -71,11 +71,6 @@ enable checking by setting the C<check> attribute option:
 
 See L<Return::Type/Options> for a more detailed explanation.
 
-=head1 METHODS
-
-The C<import> method supports the C<check> attribute to set whether or
-not types are checked.
-
 =head1 CAVEATS
 
 Disabling checks also disables coercions (if any).

--- a/lib/Return/Type/Lexical.pm
+++ b/lib/Return/Type/Lexical.pm
@@ -14,16 +14,16 @@ sub import {
 	my (%args) = @_;
 
 	$^H{'Return::Type::Lexical/check'} = exists $args{check} && !$args{check} ? 0 : 1;
-	$^H{'Return::Type::Lexical/wrap_sub_args/coerce'} = $args{coerce} if defined $args{coerce};
-	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'} = $args{coerce_list} if defined $args{coerce_list};
-	$^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'} = $args{coerce_scalar} if defined $args{coerce_scalar};
+	$^H{'Return::Type::Lexical/coerce'} = $args{coerce} if defined $args{coerce};
+	$^H{'Return::Type::Lexical/coerce_list'} = $args{coerce_list} if defined $args{coerce_list};
+	$^H{'Return::Type::Lexical/coerce_scalar'} = $args{coerce_scalar} if defined $args{coerce_scalar};
 }
 
 sub unimport {
 	delete $^H{'Return::Type::Lexical/check'};
-	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce'};
-	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_list'};
-	delete $^H{'Return::Type::Lexical/wrap_sub_args/coerce_scalar'};
+	delete $^H{'Return::Type::Lexical/coerce'};
+	delete $^H{'Return::Type::Lexical/coerce_list'};
+	delete $^H{'Return::Type::Lexical/coerce_scalar'};
 }
 
 1;

--- a/meta/doap.pret
+++ b/meta/doap.pret
@@ -12,7 +12,8 @@
 	:created              2013-10-30;
 	:license              <http://dev.perl.org/licenses/>;
 	:maintainer           cpan:TOBYINK;
-	:developer            cpan:TOBYINK.
+	:developer            cpan:TOBYINK;
+	:developer            cpan:CCM.
 
 <http://dev.perl.org/licenses/>
 	dc:title  "the same terms as the perl 5 programming language system itself".

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -8,6 +8,7 @@
 	:runtime-requirement    [ :on "Sub::Util"^^:CpanId ];
 	:runtime-requirement    [ :on "Types::Standard"^^:CpanId ];
 	:runtime-requirement    [ :on "Types::TypeTiny"^^:CpanId ];
+	:runtime-requirement    [ :on "parent"^^:CpanId ];
 	:runtime-requirement    [ :on "perl 5.008"^^:CpanId ];
 	:test-requirement       [ :on "Test::Fatal"^^:CpanId ];
 	:test-requirement       [ :on "Test::More 0.96"^^:CpanId ];

--- a/meta/people.pret
+++ b/meta/people.pret
@@ -7,3 +7,8 @@ cpan:TOBYINK
 	:page  <https://metacpan.org/author/TOBYINK>;
 	:mbox  <mailto:tobyink@cpan.org>.
 
+cpan:CCM
+	:name  "Charles McGarvey";
+	:page  <https://metacpan.org/author/CCM>;
+	:mbox  <mailto:ccm@cpan.org>.
+

--- a/t/04lexical.t
+++ b/t/04lexical.t
@@ -30,16 +30,12 @@ use constant Int1 => Int->plus_coercions(Num, sub { int($_) });
 {
 	use Return::Type::Lexical;
 	sub foo :ReturnType(Int) { 'not an int' }
-	no Return::Type::Lexical;
-	sub bar :ReturnType(Int) { 'not an int' }
-}
-
-sub baz :ReturnType(Int) { 'not an int' }
-
-{
 	use Return::Type::Lexical check => 0;
-	sub qux :ReturnType(Int) { 'not an int' }
+	sub bar :ReturnType(Int) { 'not an int' }
+	sub baz :ReturnType(Int, check => 1) { 'not an int' }
 }
+
+sub qux :ReturnType(Int) { 'not an int' }
 
 {
 	package OtherPackage;
@@ -53,34 +49,34 @@ sub baz :ReturnType(Int) { 'not an int' }
 like(
 	exception { my $rt = foo() },
 	qr{^Value "not an int" did not pass type constraint},
-	'return type enforced',
+	'check when enabled lexical',
 );
 
 is(
 	exception { my $rt = bar() },
 	undef,
-	'return type not enforced when unimport is called',
+	'no check when disabled lexical',
 );
 
 like(
 	exception { my $rt = baz() },
 	qr{^Value "not an int" did not pass type constraint},
-	'return type enforced again when outside previous scope',
+	'check in attribute overrides lexical',
 );
 
-is(
+like(
 	exception { my $rt = qux() },
-	undef,
-	'return type not enforced import called with check to 0',
+	qr{^Value "not an int" did not pass type constraint},
+	'check when outside of lexical scope',
 );
 
 like(
 	exception { my $rt = OtherPackage::muf() },
 	qr{^Value "not an int" did not pass type constraint},
-	'return type enforced when using Return::Type directly in another package',
+	'check when in another package',
 );
 
-(sub {
+{
 	use Return::Type::Lexical check => 1;
 
 	my $wrapped = Return::Type->wrap_sub(
@@ -91,11 +87,11 @@ like(
 	like(
 		exception { my $rt = $wrapped->() },
 		qr{^Value "not an int" did not pass type constraint},
-		'runtime: return type enforced when wrapping',
+		'check when enabled lexical calling wrap_sub',
 	);
-})->();
+}
 
-(sub {
+{
 	use Return::Type::Lexical check => 0;
 
 	my $wrapped = Return::Type->wrap_sub(
@@ -106,11 +102,11 @@ like(
 	is(
 		exception { my $rt = $wrapped->() },
 		undef,
-		'runtime: return type not enforced when wrapping',
+		'no check when disabled lexical calling wrap_sub',
 	);
-})->();
+}
 
-(sub {
+{
 	use Return::Type::Lexical check => 1, coerce => 1;
 
 	my $wrapped = Return::Type->wrap_sub(
@@ -121,8 +117,23 @@ like(
 	is(
 		exception { my $rt = $wrapped->(3.141592) },
 		undef,
-		'coerced with a lexical coercion setting',
+		'coerce with a lexical coercion setting',
 	);
-})->();
+}
+
+{
+	use Return::Type::Lexical check => 1, coerce => 1;
+
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 3.1415 },
+		scalar => Int1,
+		coerce => 0,
+	);
+	like(
+		exception { my $rt = $wrapped->() },
+		qr{^Value "3.1415" did not pass type constraint},
+		'attribute coerce overrides lexical coerce calling wrap_sub',
+	);
+}
 
 done_testing;

--- a/t/04lexical.t
+++ b/t/04lexical.t
@@ -23,7 +23,9 @@ use strict;
 use warnings;
 use Test::Fatal;
 use Test::More;
-use Types::Standard qw(Int);
+use Types::Standard qw(Int Num);
+
+use constant Int1 => Int->plus_coercions(Num, sub { int($_) });
 
 {
 	use Return::Type::Lexical;
@@ -89,7 +91,7 @@ like(
 	like(
 		exception { my $rt = $wrapped->() },
 		qr{^Value "not an int" did not pass type constraint},
-		'return type enforced when wrapping at runtime',
+		'runtime: return type enforced when wrapping',
 	);
 })->();
 
@@ -104,7 +106,22 @@ like(
 	is(
 		exception { my $rt = $wrapped->() },
 		undef,
-		'return type not enforced when wrapping at runtime',
+		'runtime: return type not enforced when wrapping',
+	);
+})->();
+
+(sub {
+	use Return::Type::Lexical check => 1, coerce => 1;
+
+	my $wrapped = Return::Type->wrap_sub(
+		sub { shift },
+		scalar => Int1,
+	);
+
+	is(
+		exception { my $rt = $wrapped->(3.141592) },
+		undef,
+		'coerced with a lexical coercion setting',
 	);
 })->();
 

--- a/t/04lexical.t
+++ b/t/04lexical.t
@@ -78,4 +78,34 @@ like(
 	'return type enforced when using Return::Type directly in another package',
 );
 
+(sub {
+	use Return::Type::Lexical check => 1;
+
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 'not an int' },
+		scalar => Int,
+	);
+
+	like(
+		exception { my $rt = $wrapped->() },
+		qr{^Value "not an int" did not pass type constraint},
+		'return type enforced when wrapping at runtime',
+	);
+})->();
+
+(sub {
+	use Return::Type::Lexical check => 0;
+
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 'not an int' },
+		scalar => Int,
+	);
+
+	is(
+		exception { my $rt = $wrapped->() },
+		undef,
+		'return type not enforced when wrapping at runtime',
+	);
+})->();
+
 done_testing;

--- a/t/04lexical.t
+++ b/t/04lexical.t
@@ -1,0 +1,81 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test that L<Return::Type::Lexical> works.
+
+=head1 AUTHOR
+
+Charles McGarvey E<lt>ccm@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2020 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::Fatal;
+use Test::More;
+use Types::Standard qw(Int);
+
+{
+	use Return::Type::Lexical;
+	sub foo :ReturnType(Int) { 'not an int' }
+	no Return::Type::Lexical;
+	sub bar :ReturnType(Int) { 'not an int' }
+}
+
+sub baz :ReturnType(Int) { 'not an int' }
+
+{
+	use Return::Type::Lexical check => 0;
+	sub qux :ReturnType(Int) { 'not an int' }
+}
+
+{
+	package OtherPackage;
+
+	use Types::Standard qw(Int);
+	use Return::Type;
+
+	sub muf :ReturnType(Int) { 'not an int' }
+}
+
+like(
+	exception { my $rt = foo() },
+	qr{^Value "not an int" did not pass type constraint},
+	'return type enforced',
+);
+
+is(
+	exception { my $rt = bar() },
+	undef,
+	'return type not enforced when unimport is called',
+);
+
+like(
+	exception { my $rt = baz() },
+	qr{^Value "not an int" did not pass type constraint},
+	'return type enforced again when outside previous scope',
+);
+
+is(
+	exception { my $rt = qux() },
+	undef,
+	'return type not enforced import called with check to 0',
+);
+
+like(
+	exception { my $rt = OtherPackage::muf() },
+	qr{^Value "not an int" did not pass type constraint},
+	'return type enforced when using Return::Type directly in another package',
+);
+
+done_testing;

--- a/t/05package.t
+++ b/t/05package.t
@@ -1,0 +1,96 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test that L<Return::Type> package-scoped wrap_sub args works.
+
+=head1 AUTHOR
+
+Charles McGarvey E<lt>ccm@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2020 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::Fatal;
+use Test::More;
+use Types::Standard qw(Int Num);
+
+use constant Int1 => Int->plus_coercions(Num, sub { int($_) });
+
+use Return::Type coerce => 1;
+
+sub foo :ReturnType(Int1) { 3.1415 }
+
+{
+	package OtherPackage;
+
+	use Types::Standard qw(Int Num);
+	use Return::Type;
+
+	use constant Int1 => Int->plus_coercions(Num, sub { int($_) });
+
+	sub bar :ReturnType(Int1) { 3.1415 }
+}
+
+is (
+	scalar foo(),
+	3,
+	'coerce with package-level coercion on',
+);
+
+like(
+	exception { my $rt = OtherPackage::bar() },
+	qr{^Value "3.1415" did not pass type constraint},
+	'no coercion in a different package with coercion off',
+);
+
+{
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 3.1415 },
+		scalar => Int1,
+	);
+	is(
+		exception { my $rt = $wrapped->() },
+		undef,
+		'coerce with package-level coercion on calling wrap_sub',
+	);
+}
+
+{
+	use Return::Type::Lexical coerce => 0;
+
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 3.1415 },
+		scalar => Int1,
+	);
+	like(
+		exception { my $rt = $wrapped->() },
+		qr{^Value "3.1415" did not pass type constraint},
+		'lexical coerce overrides package coerce',
+	);
+}
+
+{
+	my $wrapped = Return::Type->wrap_sub(
+		sub { 3.1415 },
+		scalar => Int1,
+		coerce => 0,
+	);
+	like(
+		exception { my $rt = $wrapped->() },
+		qr{^Value "3.1415" did not pass type constraint},
+		'attribute coerce overrides package coerce',
+	);
+}
+
+done_testing;


### PR DESCRIPTION
Major changes:
- Wraps subs at compile time.
- Adds the new module Return::Type::Lexical.
- Adds package-level configuration (based on ideas in #1)